### PR TITLE
Implement withdraw all from protocols

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -5,6 +5,11 @@ import { isAddress, isNumericString } from './typeValidator.js';
 export async function convertToTokenUnits(amount: number, chainId: number, contractAddress: string): Promise<ethers.BigNumberish> {
     const token = await getToken(chainId, contractAddress);
     const decimals = token.decimals;
+
+    // Max BigInt - For Withdraw All from protocols
+    if (amount.toString() === "115792089237316195423570985008687907853269984665640564039457584007913129639935n") {
+      return amount;
+    }
     
     // Calculate the result as a number first
     const result = amount * Math.pow(10, decimals);


### PR DESCRIPTION
convertToTokenUnits(amount: number, chainId: number, contractAddress: string)

This function will be called to calculated amount in token's unit and will expect a number.

With Withdraw All example implement, the passed in amount will be a bigint.

This new line of code will handle that case while not affecting the existing usages.