### PR TITLE
Enable SCRIPT block, add examples, bump to 2.0.558

### DIFF
--- a/examples/Script/aave-supply-rate-multiplier.ts
+++ b/examples/Script/aave-supply-rate-multiplier.ts
@@ -1,0 +1,96 @@
+import { TRIGGERS, Trigger, CHAINS, getTokenFromSymbol, apiServices, WORKFLOW_LOOPING_TYPES } from '../../src/index.js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+/**
+ * SCRIPT block: take the AAVE USDC supply rate (Ethereum) and return it × 2.2.
+ *
+ * The AAVE LENDING_RATE trigger emits `lendingRate` (float, %).
+ * We pass it into the SCRIPT node's parameters via the `{{nodeMap.<ref>.output.<key>}}`
+ * template — the runtime resolves the templates before invoking the script,
+ * so `env.parameters.rate` is already the numeric rate at execution time.
+ *
+ * Same caveats as the inline-script example apply (admin token required, raw JSON node).
+ */
+
+const SCRIPT_BLOCK_ID = 100037;
+
+async function main() {
+  if (!process.env.API_URL || !process.env.AUTH_TOKEN) {
+    throw new Error('API_URL and AUTH_TOKEN must be set in .env');
+  }
+
+  apiServices.setUrl(process.env.API_URL);
+  apiServices.setAuth(process.env.AUTH_TOKEN);
+
+  const usdc = getTokenFromSymbol(CHAINS.ETHEREUM, 'USDC').contractAddress;
+
+  // Trigger: AAVE USDC lending rate on Ethereum, condition `gte 0` so it always fires.
+  const trigger = new Trigger(TRIGGERS.LENDING.AAVE.LENDING_RATE);
+  trigger.setChainId(CHAINS.ETHEREUM);
+  trigger.setParams('asset', usdc);
+  trigger.setParams('condition', 'gte');
+  trigger.setParams('comparisonValue', 0);
+  trigger.setPosition(200, 120);
+
+  const scriptNode = {
+    ref: 'script',
+    blockId: SCRIPT_BLOCK_ID,
+    type: 'action',
+    parameters: {
+      rate: trigger.getOutputVariableName('lendingRate'),
+      multiplier: 2.2,
+    },
+    handler: `(env) => {
+      const rate = parseFloat(env.parameters.rate);
+      const multiplier = parseFloat(env.parameters.multiplier);
+      return {
+        aaveSupplyRate: rate,
+        multiplier,
+        result: rate * multiplier,
+      };
+    }`,
+    position: { x: 200, y: 240 },
+  };
+
+  const payload = {
+    name: 'SDK example: AAVE USDC supply rate × 2.2',
+    nodes: [trigger.toJSON(), scriptNode],
+    edges: [{ source: trigger.getRef(), target: scriptNode.ref }],
+    settings: {
+      loopingType: WORKFLOW_LOOPING_TYPES.SUBSCRIPTION,
+      limit: 1,
+      timeout: 60_000,
+    },
+  };
+
+  const created = await apiServices.post('/workflows', payload);
+  const workflowId = created.data.id;
+  console.log('Workflow created:', workflowId);
+
+  await apiServices.post(`/workflows/${workflowId}/run`, {});
+  console.log('Workflow started. Polling for completion…');
+
+  for (let i = 0; i < 30; i++) {
+    await new Promise((r) => setTimeout(r, 2000));
+    const wf = await apiServices.get(`/workflows/${workflowId}`);
+    if (!wf.executionId) continue;
+    const exec = await apiServices.get(`/executions/${wf.executionId}`);
+    const scriptOutput = exec.workflow.nodes.find((n: any) => n.ref === 'script');
+    if (scriptOutput?.state === 'completed') {
+      console.log('Script output:', scriptOutput.output);
+      return;
+    }
+    if (scriptOutput?.state === 'failed') {
+      console.error('Script failed:', scriptOutput);
+      return;
+    }
+  }
+  console.warn('Timed out waiting for script to complete.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/Script/inline-script.ts
+++ b/examples/Script/inline-script.ts
@@ -1,0 +1,95 @@
+import { TRIGGERS, Trigger, apiServices, WORKFLOW_LOOPING_TYPES } from '../../src/index.js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+/**
+ * SCRIPT block (blockId 100037)
+ *
+ * The SCRIPT block runs an inline JavaScript function on the Otomato runtime.
+ * The function receives `env` (with `parameters` and upstream node outputs)
+ * and must return a JSON-serializable value, which becomes the node's output.
+ *
+ * Caveats today:
+ *   - Only admin tokens (xtoken:...) can submit workflows containing this block;
+ *     non-admin tokens are rejected by the BANNED_BLOCK_IDS check on the server.
+ *   - The block is not yet exposed as a typed Action in the SDK
+ *     (its `parameters` array is empty and the Action class does not surface
+ *     the `handler` field). This example builds the node JSON directly and
+ *     submits the workflow via `apiServices.post('/workflows', ...)`.
+ */
+
+const SCRIPT_BLOCK_ID = 100037;
+
+async function main() {
+  if (!process.env.API_URL || !process.env.AUTH_TOKEN) {
+    throw new Error('API_URL and AUTH_TOKEN must be set in .env');
+  }
+
+  apiServices.setUrl(process.env.API_URL);
+  apiServices.setAuth(process.env.AUTH_TOKEN);
+
+  // 1) Trigger: every 24h, runs once. We use the SDK to build a valid trigger node.
+  const trigger = new Trigger(TRIGGERS.CORE.EVERY_PERIOD.EVERY_PERIOD);
+  trigger.setParams('period', 86_400_000);
+  trigger.setParams('limit', 1);
+  trigger.setPosition(200, 120);
+
+  // 2) SCRIPT node — built as raw JSON (see caveats above).
+  //    `handler` is the function the runtime will execute.
+  //    `parameters` are passed in via `env.parameters`.
+  const scriptNode = {
+    ref: 'script',
+    blockId: SCRIPT_BLOCK_ID,
+    type: 'action',
+    parameters: { greeting: 'hello from inline script' },
+    handler: `(env) => {
+      const { greeting } = env.parameters;
+      return { ok: true, echoed: greeting, ranAt: new Date().toISOString() };
+    }`,
+    position: { x: 200, y: 240 },
+  };
+
+  const payload = {
+    name: 'SDK example: SCRIPT block',
+    nodes: [trigger.toJSON(), scriptNode],
+    edges: [{ source: trigger.getRef(), target: scriptNode.ref }],
+    settings: {
+      loopingType: WORKFLOW_LOOPING_TYPES.SUBSCRIPTION,
+      limit: 1,
+      timeout: 60_000,
+    },
+  };
+
+  const created = await apiServices.post('/workflows', payload);
+  const workflowId = created.data.id;
+  console.log('Workflow created:', workflowId);
+
+  await apiServices.post(`/workflows/${workflowId}/run`, {});
+  console.log('Workflow started. Polling for completion…');
+
+  // Poll the latest execution until both nodes are no longer pending.
+  for (let i = 0; i < 20; i++) {
+    await new Promise((r) => setTimeout(r, 2000));
+    const wf = await apiServices.get(`/workflows/${workflowId}`);
+    const execId = wf.executionId;
+    if (!execId) continue;
+
+    const exec = await apiServices.get(`/executions/${execId}`);
+    const scriptOutput = exec.workflow.nodes.find((n: any) => n.ref === 'script');
+    if (scriptOutput?.state === 'completed') {
+      console.log('Script output:', scriptOutput.output);
+      return;
+    }
+    if (scriptOutput?.state === 'failed') {
+      console.error('Script failed:', scriptOutput);
+      return;
+    }
+  }
+  console.warn('Timed out waiting for script to complete.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otomato-sdk",
-  "version": "2.0.556",
+  "version": "2.0.558",
   "description": "An SDK for building and managing automations on Otomato",
   "repository": {
     "type": "git",

--- a/src/constants/version.ts
+++ b/src/constants/version.ts
@@ -1,4 +1,4 @@
-export const SDK_VERSION = '2.0.486';
+export const SDK_VERSION = '2.0.558';
 
 export function compareVersions(v1: string, v2: string): number {
     // Split the version strings into parts


### PR DESCRIPTION
## Summary
- Removes \`comingSoon: true\` from the SCRIPT block (blockId 100037) so it surfaces in clients (dapp).
- Adds two SDK examples under \`examples/Script/\`:
  - \`inline-script.ts\` — minimal SCRIPT node with an inline handler.
  - \`aave-supply-rate-multiplier.ts\` — AAVE USDC supply rate (Ethereum) × 2.2.
- Bumps \`package.json\` 2.0.556 → 2.0.558 (npm registry already has 2.0.557 from a prior commit).

## Notes
- Examples submit SCRIPT nodes via raw JSON through \`apiServices.post\` because the typed \`Action\` wrapper does not yet expose the \`handler\` field. Documented inline.
- The block is still server-banned for non-admin tokens (\`BANNED_BLOCK_IDS\` in webserver/src/constants.ts). Removing \`comingSoon\` only affects client UI gating, not server authorization.

## Test plan
- [x] Built locally (\`npm run build\`)
- [x] Both examples run end-to-end against staging (verified outputs)
- [ ] CI green (npm test + build) before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)