### PR TITLE
Add STRING_KEYWORD_DETECTION block (id 100048), bump to 2.0.560

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otomato-sdk",
-  "version": "2.0.557",
+  "version": "2.0.560",
   "description": "An SDK for building and managing automations on Otomato",
   "repository": {
     "type": "git",

--- a/src/constants/version.ts
+++ b/src/constants/version.ts
@@ -1,4 +1,4 @@
-export const SDK_VERSION = '2.0.558';
+export const SDK_VERSION = '2.0.560';
 
 export function compareVersions(v1: string, v2: string): number {
     // Split the version strings into parts


### PR DESCRIPTION
## Summary
- Surfaces the new `STRING_KEYWORD_DETECTION` block (id 100048) merged in [bmt #476](https://github.com/Otomatorg/block-management-tool/pull/476)
- Bumps SDK version `2.0.557 → 2.0.560` so consumers (otomato-dapp already on `^2.0.559`) can pick up the new block

## Test plan
- [x] Block verified end-to-end on staging via SDK workflows (AAVE rate trigger and X tweet subscription)

🤖 Generated with [Claude Code](https://claude.com/claude-code)