### PR TITLE
#2763 remove broken Dune-backed wallet-activity template, hide block 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otomato-sdk",
-  "version": "2.0.604",
+  "version": "2.0.605",
   "description": "An SDK for building and managing automations on Otomato",
   "repository": {
     "type": "git",

--- a/src/constants/WorkflowTemplates.ts
+++ b/src/constants/WorkflowTemplates.ts
@@ -557,28 +557,10 @@ const createDefillamaRaiseNotificationWorkflow = () => {
     return workflow;
 };
 
-const createTokenMovementNotificationWorkflow = () => {
-    const trigger = new Trigger(TRIGGERS.TOKENS.BALANCE.BALANCE_MOVEMENT);
-    // trigger.setParams('walletAddress', '{{smartAccountAddress}}');
-    trigger.setPosition(400, 120);
+// #2763: createTokenMovementNotificationWorkflow removed — its trigger
+// (BALANCE_MOVEMENT, block 6) polls the sunsetted Dune Sim API and no longer works.
 
-    const telegramAction = new Action(ACTIONS.NOTIFICATIONS.TELEGRAM.SEND_MESSAGE);
-    telegramAction.setParams('message', trigger.getOutputVariableName('balanceChanges'));
-    telegramAction.setPosition(400, 240);
-
-    const edge = new Edge({ source: trigger, target: telegramAction });
-
-    const workflow = new Workflow(
-        'Token Movement Notification',
-        [trigger, telegramAction],
-        [edge],
-        DEFAULT_WORKFLOW_LOOP_SETTINGS.polling5s
-    );
-
-    return workflow;
-};
-
-const createTwitterAiNotificationWorkflow = (username: { display: string, tag: string }, wfData: { prompt: string, notification: string, wfTitle: string }) => {
+const createTwitterAiNotificationWorkflow =(username: { display: string, tag: string }, wfData: { prompt: string, notification: string, wfTitle: string }) => {
     return () => {
         const trigger = new Trigger(TRIGGERS.SOCIALS.X.X_POST_TRIGGER);
         trigger.setParams('username', username.tag);
@@ -1431,22 +1413,8 @@ export const WORKFLOW_TEMPLATES = [
         ],
         createWorkflow: createEthereumFoundationTransferNotificationWorkflow
     },
-    {
-        'id': 7,
-        'name': 'Receive alerts for wallet activity',
-        'description': 'Get notified when a given wallet receives or sends any token on any chain',
-        'tags': [WORKFLOW_TEMPLATES_TAGS.SOCIALS, WORKFLOW_TEMPLATES_TAGS.NOTIFICATIONS],
-        'thumbnail': 'https://otomato-sdk-images.s3.eu-west-1.amazonaws.com/templates/transfer_alert.webp',
-        'image': [
-            TRIGGERS.TOKENS.BALANCE.image,
-            ACTIONS.NOTIFICATIONS.TELEGRAM.image
-        ],
-        'blockIDs': [
-            TRIGGERS.TOKENS.BALANCE.BALANCE_MOVEMENT.blockId,
-            ACTIONS.NOTIFICATIONS.TELEGRAM.SEND_MESSAGE.blockId
-        ],
-        createWorkflow: createTokenMovementNotificationWorkflow
-    },
+    // #2763: template id 7 'Receive alerts for wallet activity' removed — built on the
+    // BALANCE_MOVEMENT block (id 6) which polls the sunsetted Dune Sim API and is now broken.
     createTwitterAiNotificationTemplate(
         8,
         { display: 'Strategy', tag: 'Strategy' },


### PR DESCRIPTION
## Summary
- The `BALANCE_MOVEMENT` trigger (block id 6, "Balance movement") fetches balances from `api.sim.dune.com`. Dune is retiring the Sim API on 2026-08-01 (new signups already disabled), so the trigger can no longer fetch balances and every alert/workflow built on it is broken (closes #2763).
- Remove the only marketplace template that uses it — `WORKFLOW_TEMPLATES` id 7 "Receive alerts for wallet activity" (`createTokenMovementNotificationWorkflow`).
- Hide the trigger from the builder palette via `hideInLeftPanel: true` (canonical source in BMT `balance.js`; surgical splice into the generated SDK `Blocks.ts` the dapp reads). The dapp's block picker hides any block whose object carries the `hideInLeftPanel` key (`collapses/index.tsx:61`).
- The block definition is **kept, not deleted**, so existing stored workflows that reference block 6 still resolve. The other balance blocks (id 5 `BALANCE`, id 92 `INDIVIDUAL_BALANCE_MOVEMENT`) are on-chain and untouched.
- The ticket was filed in otomato-dapp and says "remove from the decoder", but the decoder has zero references to this block/Dune; the user-facing surface lives in `otomato-sdk` (template) + `block-management-tool` (block). The dapp renders the SDK list verbatim and needs no change — it picks up the removal on its next SDK bump.

## Test plan
- **Reproduction (bug present):** block 6's real `before()` + live fetch → `HTTP 401 invalid API Key`; Dune Sim retirement confirmed via Dune/Allium/Alchemy migration notices.
- **Removal verified** against the freshly-built `otomato-sdk` bundle (4/4 assertions):
  - template id 7 absent from `WORKFLOW_TEMPLATES` — PASS
  - no template references block 6 in `blockIDs` — PASS
  - block 6 still resolvable, now `hideInLeftPanel=true` — PASS
  - every remaining template still builds — 70/70 PASS
- `npx tsc` clean.
- No agent-test spec covers marketplace templates / balance blocks and block 6 is a BMT trigger (no decoder handler), so the deterministic bundle assertion substitutes for agent-test and the block-6 real-code-path repro substitutes for the block-tester live run.
- **QA report:** https://html.otomato.xyz/reports/2763-balance-movement-dune-sunset-2026-06-25-0240.html

## Related PRs (#2763, ship together)
- otomato-sdk — #141 (template removal + hide block 6)
- otomato-decoder — #349 (main) / #350 (prod) — stop auto-starting the balance wf
- block-management-tool — #580 (main) / #581 (prod) — `hideInLeftPanel` on block 6
