### PR TITLE
#2893 add Monad (chainId 143) chain, MON tokens, RPC wiring

### DIFF
--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -15,6 +15,7 @@ export const CHAINS = {
   HYPER_EVM: 999,
   SCROLL: 534352,
   MANTLE: 5000,   
-  INK: 57073,                                                                                                               
+  INK: 57073,
   PLASMA: 9745,
+  MONAD: 143,
 };

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -2132,6 +2132,52 @@ export const TOKENS: Tokens = {
       decimals: 18,
       image: null,
     },
+  ],
+  143: [
+    {
+      contractAddress: "0x0000000000000000000000000000000000000000",
+      name: "Monad",
+      symbol: "MON",
+      decimals: 18,
+      nativeCurrency: true,
+      equivalentERC20: "0x3bd359c1119da7da1d913d1c4d2b7c461115433a",
+      image: null,
+    },
+    {
+      contractAddress: "0x3bd359c1119da7da1d913d1c4d2b7c461115433a",
+      name: "Wrapped Monad",
+      symbol: "WMON",
+      decimals: 18,
+      image: null,
+    },
+    {
+      contractAddress: "0x754704bc059f8c67012fed69bc8a327a5aafb603",
+      name: "USDC",
+      symbol: "USDC",
+      decimals: 6,
+      image: null,
+    },
+    {
+      contractAddress: "0xe7cd86e13ac4309349f30b3435a9d337750fc82d",
+      name: "USDT0",
+      symbol: "USDT0",
+      decimals: 6,
+      image: null,
+    },
+    {
+      contractAddress: "0xee8c0e9f1bffb4eb878d8f15f368a02a35481242",
+      name: "Wrapped Ether",
+      symbol: "WETH",
+      decimals: 18,
+      image: null,
+    },
+    {
+      contractAddress: "0xfc421ad3c883bf9e7c4f42de845c4e4405799e73",
+      name: "GHO",
+      symbol: "GHO",
+      decimals: 18,
+      image: null,
+    },
   ]
 };
 

--- a/src/services/RpcServices.ts
+++ b/src/services/RpcServices.ts
@@ -56,6 +56,9 @@ class RPCServices {
     if (env.INK_HTTPS_PROVIDER) {
       this.rpcUrls[CHAINS.INK] = env.INK_HTTPS_PROVIDER;
     }
+    if (env.MONAD_HTTPS_PROVIDER) {
+      this.rpcUrls[CHAINS.MONAD] = env.MONAD_HTTPS_PROVIDER;
+    }
   }
 
   // Function to get the RPC URL for a specific chainId


### PR DESCRIPTION
## Summary

Add **Monad** (chainId 143, native MON) support for **Aave, Morpho and Pendle** — power-user request (#2893). All three protocols are live on Monad and their data sources serve chain 143 (Aave V3.7, Morpho Blue, Pendle api-v2), verified against live endpoints before wiring.

This is one coordinated change across 6 repos. Per-repo part:

- **otomato-sdk** — `CHAINS.MONAD=143`, `TOKENS[143]` (MON native + WMON/USDC/USDT0/WETH/GHO), `MONAD_HTTPS_PROVIDER` RPC wiring.
- **sharedlibs** — `CHAINS.MONAD=143` (block-dropdown enum).
- **custom-handler** — `'monad'` added to `DEBANK_CHAIN_IDS` (the position-detection gate — the noti agent only iterates Debank-surfaced chains, learnings #2225) + `BARE_WALLET_CHAIN_SLUG_TO_ID.monad=143`.
- **otomato-decoder** — `getChainName(143)='Monad'`; `protocolChainsSupported` aave/morpho/pendle += MONAD; `AAVE_V3_CHAINS` and Pendle `SUPPORTED_CHAIN_IDS` += 143.
- **block-management-tool** — Aave Pool/UiPoolDataProvider/AddressesProvider/DataProvider maps + Morpho Blue address for Monad; aave/morpho/pendle chain dropdowns += MONAD.
- **connection-points-data-puller** — aave/morpho/pendle puller `SUPPORTED_CHAINS` += 143; `conf.js` Monad RPC.

**Release ordering (hard):** merge + **publish otomato-sdk first**, then bump `otomato-sdk` in the consumer repos — `CHAINS.MONAD` is undefined in consumers until then. Set `MONAD_HTTPS_PROVIDER` on staging + prod (defaults to public `rpc.monad.xyz`; a paid provider is recommended for prod).

Monad addresses (all cross-checked with `eth_getCode` on-chain):
| Contract | Address |
|---|---|
| Aave Pool | `0x69a5F9AD4f96ebf0a0C792dD42a01cC5C0102fef` |
| Aave AddressesProvider | `0x34793Fb9935F7bB5E5aE920fb963F39063E7A615` |
| Aave DataProvider | `0xB65A68B98274ef7D9a60E0C0747dD1BEc3D32fad` |
| Aave UiPoolDataProvider | `0xa7D38785be3422c25677A8aa4a44D3a0853A3a17` |
| Morpho Blue (Monad) | `0xD5D960E8C380B724a48AC59E2DfF1b2CB4a1eAee` |
| WMON | `0x3bd359c1119da7da1d913d1c4d2b7c461115433a` |

## Test plan

See the full plan and evidence in the QA report: https://html.otomato.xyz/reports/monad-aave-morpho-pendle-2893-2026-07-22.html

- Live probes: RPC `0x8f`; Aave 12 reserves; Morpho API indexes `{id:143}`; Pendle 3 active markets (AUSD ~$5.7M).
- Decoder gating harness (real `index.js`) — 11/11 PASS: `getChainName(143)="Monad"`, all 3 protocols gate 143 in, `transformArgsData` keeps Monad positions (positionKey `<protocol>:143:…`), negative control filters an unsupported chain.
- BMT `validate:functions` OK (679 function strings); Monad addresses present in generated `webserverTriggers.json`.
