### PR TITLE
fix(test): update ionicLendingRate expected output to include smartAlert default

### DIFF
--- a/test/externalVariables.spec.ts
+++ b/test/externalVariables.spec.ts
@@ -68,7 +68,10 @@ describe('external variables construction from object', () => {
             [{"key": "chainId", "value": 34443}, {"key": "token", "value": "0xf0F161fDA2712DB8b566946122a5af183995e2eD"}],
         );
 
-        expect(variable).to.equal('{{external.functions.ionicLendingRate(34443,0xf0F161fDA2712DB8b566946122a5af183995e2eD,,)}}');
+        // 5th arg `false` is the `smartAlert` block param default added post-#2656
+        // (rates rearm). `getExternalVariableFromParameters` emits block defaults for
+        // params the user didn't provide, so `smartAlert:false` becomes a trailing arg.
+        expect(variable).to.equal('{{external.functions.ionicLendingRate(34443,0xf0F161fDA2712DB8b566946122a5af183995e2eD,,,false)}}');
     });
 
     it('should create sUSDE yield', () => {


### PR DESCRIPTION
## Summary
- Update `test/externalVariables.spec.ts:71` expected string from `,,` to `,,false`
- `ionicLendingRate` block gained `smartAlert` (value: false) as 5th param via #2656 rates-rearm work
- `getExternalVariableFromParameters` emits block defaults for unspecified params, so the trailing `false` is correct
- Also added a code comment explaining the schema-driven emit

## Test plan
- `npm test` — all 199 non-apiKey tests pass (only remaining failure is missing local `API_KEY` env, unrelated)
- Failing test before: `AssertionError: expected '...(34443,0x...,,,false)' to equal '...(34443,0x...,,)`
- Failing test after: passes

## Why not fix the emit function instead
Silently dropping `smartAlert=false` from the emitted mustache would change the value the decoder receives from `false` to `undefined`. The `smartAlert` bit is load-bearing for whether the rearm engine takes over vs plain metric compare (per #2656). Silently dropping = silently changing rearm behavior across all workflows using this block. The test is the right layer to update, not the function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)