### PR TITLE
chore: bump version to 2.0.631 (unblock release after #144)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otomato-sdk",
-  "version": "2.0.630",
+  "version": "2.0.631",
   "description": "An SDK for building and managing automations on Otomato",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- PR #144 shipped an ionicLendingRate test fix without bumping the version
- Release workflow tried to republish 2.0.630 to npm → rejected (`You cannot publish over the previously published versions`)
- Bump to 2.0.631 so the next master push republishes cleanly

## Test plan
- `npm version 2.0.631 --no-git-tag-version` — atomic edit, no git tag left dangling
- After merge → SDK Release workflow fires on master push → publishes otomato-sdk@2.0.631

🤖 Generated with [Claude Code](https://claude.com/claude-code)