### PR TITLE
#2893 bump version to 2.0.645 to publish Monad support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otomato-sdk",
-  "version": "2.0.630",
+  "version": "2.0.645",
   "description": "An SDK for building and managing automations on Otomato",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Publish is stuck: master package.json was 2.0.630 but npm latest is 2.0.644, so the SDK Release workflow fails with 'cannot publish over previously published versions'. Bumps to 2.0.645 (above npm) so the Monad change already on master (CHAINS.MONAD, MON tokens, RPC wiring) actually publishes. TMS + other consumers need this on npm.