### PR TITLE
#3038 add Robinhood Chain (4663) to CHAINS, RPC registry and token list

### DIFF
--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -18,4 +18,5 @@ export const CHAINS = {
   INK: 57073,
   PLASMA: 9745,
   MONAD: 143,
+  ROBINHOOD: 4663,
 };

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -2080,6 +2080,57 @@ export const TOKENS: Tokens = {
       nativeCurrency: true,
     },
   ],
+  4663: [
+    {
+      contractAddress: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73",
+      name: "WETH",
+      symbol: "WETH",
+      decimals: 18,
+      image: null,
+    },
+    {
+      contractAddress: "0x117cc2133c37B721F49dE2A7a74833232B3B4C0C",
+      name: "SPDR S&P 500 ETF Trust • Robinhood Token",
+      symbol: "SPY",
+      decimals: 18,
+      image: null,
+    },
+    {
+      contractAddress: "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168",
+      name: "Global Dollar",
+      symbol: "USDG",
+      decimals: 6,
+      image: null,
+    },
+    {
+      contractAddress: "0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34",
+      name: "USDe",
+      symbol: "USDe",
+      decimals: 18,
+      image: null,
+    },
+    {
+      contractAddress: "0x40858070814a57FdF33a613ae84fE0a8b4a874f7",
+      name: "syrupUSDG",
+      symbol: "syrupUSDG",
+      decimals: 6,
+      image: null,
+    },
+    {
+      contractAddress: "0xFEd493F38c1aAcb4EA4e6A11F8b9287849EE0096",
+      name: "Midas Fasanara Global Open",
+      symbol: "mGLO",
+      decimals: 18,
+      image: null,
+    },
+    {
+      contractAddress: "0xde770c84FE66E063336b31737cFE9790f18c4087",
+      name: "Spark Savings USDG",
+      symbol: "spUSDG",
+      decimals: 6,
+      image: null,
+    },
+  ],
   9745: [
     {
       contractAddress: "0x6100e367285b01f48d07953803a2d8dca5d19873",

--- a/src/services/RpcServices.ts
+++ b/src/services/RpcServices.ts
@@ -59,6 +59,9 @@ class RPCServices {
     if (env.MONAD_HTTPS_PROVIDER) {
       this.rpcUrls[CHAINS.MONAD] = env.MONAD_HTTPS_PROVIDER;
     }
+    if (env.ROBINHOOD_HTTPS_PROVIDER) {
+      this.rpcUrls[CHAINS.ROBINHOOD] = env.ROBINHOOD_HTTPS_PROVIDER;
+    }
   }
 
   // Function to get the RPC URL for a specific chainId


### PR DESCRIPTION
## Summary
- `CHAINS.ROBINHOOD = 4663` (Arbitrum Orbit L2, `rpc.mainnet.chain.robinhood.com`).
- `RpcServices` reads `ROBINHOOD_HTTPS_PROVIDER`.
- `TOKENS[4663]`: WETH, SPY, USDG, USDe, syrupUSDG, mGLO, spUSDG — the wrapped native plus the loan and
  collateral assets of every listed Morpho market on the chain. `getToken()` throws "Unsupported chain"
  for a chain absent from `TOKENS`, so this entry is a hard prerequisite for any 4663 block; with it in
  place an unknown LP token falls through to an on-chain read via the RPC entry above.

Part of the chain-4663 bring-up for `Otomatorg/otomato-dapp#3038`. Nine repos; the hard release order
(otomato-sdk publishes first) is in the QA report's §8 and repeated at the bottom of this description.

📊 **QA report:** https://html.otomato.xyz/reports/3038-robinhood-chain-4663-2026-09-02.html

## Test plan

All numbers below are from live runs captured 2026-09-02; nothing is asserted from reading the code.
Full detail, with the real inputs and outputs at every step:
[QA report](https://html.otomato.xyz/reports/3038-robinhood-chain-4663-2026-09-02.html).

### Chain discovery (nothing copied from another chain)
`0xC36442b4…` (Uniswap V3 NFPM elsewhere) and `0xBBBB…FFCb` (Morpho Blue elsewhere) hold **unrelated
bytecode** on 4663, so every address was read off the chain and functionally confirmed:

| Contract | Address on 4663 | Confirmed by |
|---|---|---|
| Uniswap V3 NonfungiblePositionManager | `0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3` | `name()` = "Uniswap V3 Positions NFT-V1" |
| Uniswap V3 Factory | `0x1f7d7550B1b028f7571E69A784071F0205FD2EfA` | `NFPM.factory()` |
| Uniswap V4 PositionManager | `0x58daec3116aae6D93017bAAea7749052E8a04fA7` | `nextTokenId` 1,502,879; canonical CREATE2 deployer; Debank reports it as `pool.controller` |
| Uniswap V4 StateView | `0xF3334192D15450CdD385c8B70e03f9A6bD9E673b` | `getSlot0(live poolId)` → tick −1972 |
| Morpho Blue | `0x9D53d5E3bd5E8d4Cbfa6DB1ca238AEA02E651010` | blue-api **and** Debank `pool.controller` agree |

### Unit — agent-test (Jest)
- `uniswap.spec.ts` **9/9 PASS**, including two new chain-4663 cases and a guard that a position id can
  never degrade to `uniswap_v3-null-…` / `-hood-`.
- Whole `agents/agent-noti-hyperevm` suite, identical submodules:
  `origin/main` = 40 suites / 145 tests failed, 120 passed · with #3038 = 39 suites / 138 tests failed,
  130 passed. **Suites regressed: 0. Suites fixed: 1.**
- `morpho.spec.ts` is red on an untouched `origin/main` (2 failed / 2 total, empty failure bodies, ESM
  teardown race), so the Morpho half is covered by the sanctioned `.mjs` fallback:
  `test/repro/3038-robinhood-chain-4663.mjs` — **19/19 scenarios PASS** against the real decoder bundle,
  including a negative (aave must *not* admit 4663).

### End-to-end — live docker stack + live chain
block-tester run from the ticket worktrees so it resolves the branch versions of decoder / sdk /
sharedlibs / custom-handler, against `rpc.mainnet.chain.robinhood.com` and live Debank.

| Profile | Wallet | Shape | Workflows on 4663 |
|---|---|---|---|
| morpho — target | `0x502D222e…78fB3` | $11.9M, 2 markets, HF 1.019 | 4 (`morpho-hf` ×2, `morpho-borrowing` ×2) |
| morpho — second | `0x8986F939…5298` | HF 1.006 | 2 |
| uniswap V3 — rich | `0x1195C074…6DCE` | $152k, 242 positions | 726 |
| uniswap V4 — rich | `0x9978282a…C218` | $31.7k, 113 positions | 339 |
| uniswap V4 — edge | `0x3BE9eC4E…8182` | $1, one full-range position | 3 |

All five `success=true`. Thresholds are derived live, not hard-coded:
`morphoBorrowingRate(4663, 0x919a9b6b…)` → `4.065` → alert at 5.28%, and `…(4663, 0xc845da65…)` →
`4.19` → 5.44%. The chain reaches the copy as **"on Morpho (Robinhood)"**.

### Trigger blocks against the live chain
- **block 48** (V3 in-range), tokenId 955178 → `isInRange: true`, USDG/USAR, tick 247636 in 245820–249900.
  The pool the block *computed* from the factory address was re-checked independently:
  `eth_getCode` → 22,142 bytes and `slot0().tick` → **247636**, the same tick.
- **block 49** (V4 in-range), tokenId 1482821 → `isInRange: false` (tick 324320 below the 332000–333200
  band) and tokenId 208763 (dust, full range) → `isInRange: true`. Two different verdicts — the run is
  not vacuous.
- Generated block defs: blocks 39/54/55/265 carry the 4663 market list, block 54 carries the 4663 Morpho
  Blue address, **zero blocks carry an `"undefined"` address key**, `validate:functions` 679/679.

### Robustness
- **API shape variance** — 5 real Debank payloads through `shape-diff.mjs`. The load-bearing variants
  (`pool.index` string-vs-null, `position_index` numeric-vs-32-byte-id, `reward_token_list` absent on
  Morpho items) were all exercised by the five runs above.
- **Sibling regression** — the same runs still armed chains 1 / 8453 / 143 / 5000 / 9745. block 48 on
  Base still resolves its own addresses and reads a live position. Pre-existing market dropdowns
  (1/137/143/999/8453/42161) intact; all 6,373 pre-existing CPDP rows byte-identical (0 missing,
  0 modified).

### Not covered — stated, not papered over
- Morpho **vault** blocks (38 / 263 / 266) get no 4663 option: Robinhood has **zero** v1 MetaMorpho
  vaults (26 v2 vaults, which blue-api serves under `vaultV2s` and Otomato consumes on no chain).
- Uniswap swap-tracking blocks (28 / 33) are `EVM_SUBSCRIPTION` and Robinhood publishes no websocket
  (probed: 400 / NXDOMAIN). `ROBINHOOD_WSS_PROVIDER` is in the vault templates for the day one exists.

### Release order (hard)
1. Merge + **publish** `otomato-sdk` — consumers pin `^2.0.x` and each ships its own copy.
2. Bump the SDK pin in `otomato-decoder` (deploy uses `npm ci`), `block-management-tool`, `sharedlibs`.
3. Merge `connection-points-data-puller`, bump the BMT submodule to it, re-run the BMT Main Workflow.
4. Merge custom-handler / decoder / BMT; deploy.
5. Ops: write `ROBINHOOD_HTTPS_PROVIDER` into `core-services/{webserver,tms}.{staging,prod}` Vault, redeploy.
6. Refresh existing agents so they pick up the changed `settings.json` chainIds.

The six Uniswap address maps are built **at runtime** from the deployed SDK — skip step 2 and they key on
`undefined`, `contractAddress` resolves to `undefined`, and every 4663 tick throws. Verify after deploy:
`select before from block where id=48` must carry a `"4663"` key, never `"undefined"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014icT8KkMjJHY66GE6WfsP7
