### PR TITLE
fix(test): pick a Mode RPC that serves the calls under test

### DIFF
--- a/test/addressBalance.spec.ts
+++ b/test/addressBalance.spec.ts
@@ -2,15 +2,64 @@
 import { expect } from 'chai';
 import { getUserProtocolBalances, rpcServices } from '../src/index.js';
 
+/** Ionic mUSDT on Mode — a wrapper this suite actually reads. */
+const MODE_PROBE_TOKEN = '0x94812F2eEa03A49869f95e1b5868C6f3206ee3D3';
+
+/**
+ * First candidate that can serve the calls getUserProtocolBalances makes.
+ *
+ * Probing eth_chainId is NOT sufficient: mode.drpc.org answers eth_chainId and
+ * balanceOf/decimals fine but returns "Temporary internal error" for symbol().
+ * Because the implementation reads all three under one Promise.all, that single
+ * rejection drops the whole entry — and Promise.allSettled then swallows it, so
+ * the caller sees [] instead of an error (otomato-dapp#3046). Probe with the
+ * discriminating call, not the cheap one.
+ */
+async function firstLiveRpc(candidates: (string | undefined)[], token: string): Promise<string> {
+  const urls = candidates.filter((u): u is string => Boolean(u));
+  const symbolSelector = '0x95d89b41';
+  for (const url of urls) {
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'eth_call',
+          params: [{ to: token, data: symbolSelector }, 'latest'],
+        }),
+        signal: AbortSignal.timeout(5000),
+      });
+      if (!res.ok) continue;
+      const body = await res.json();
+      if (body?.result && !body?.error) return url;
+    } catch {
+      // unreachable or timed out — try the next candidate
+    }
+  }
+  return urls[urls.length - 1];
+}
+
 describe('getUserProtocolBalances', function() {
   // Adjust timeouts if calling real networks
   this.timeout(30000);
 
-  before(() => {
-    // Suppose we set the RPC for chain 8453 (Base) and 34443 (Mode)
+  before(async () => {
+    // These are live-network reads, so pinning one RPC makes the suite hostage
+    // to a single host. Probe candidates and take the first that serves the
+    // calls this code actually makes (see firstLiveRpc).
     rpcServices.setRPCs({
       8453: process.env.BASE_HTTPS_PROVIDER || 'https://base.llamarpc.com',
-      34443: 'https://mainnet.mode.network/',
+      34443: await firstLiveRpc(
+        [
+          process.env.MODE_HTTPS_PROVIDER,
+          'https://mainnet.mode.network',
+          'https://1rpc.io/mode',
+          'https://mode.drpc.org',
+        ],
+        MODE_PROBE_TOKEN,
+      ),
     });
   });
 


### PR DESCRIPTION
## Summary
- unpin the Mode RPC in `test/addressBalance.spec.ts`; probe a candidate list and use the first that answers, honouring `MODE_HTTPS_PROVIDER` when set
- the suite pinned `https://mainnet.mode.network`, and that host not answering from CI runners failed SDK Release — blocking every publish (npm stuck at `2.0.647` while `master` reached `2.0.641`)

The probe issues `eth_call symbol()`, not `eth_chainId`. That distinction is load-bearing: `mode.drpc.org` answers `eth_chainId`, `balanceOf` and `decimals` but returns `Temporary internal error` for `symbol()`, and `getUserProtocolBalances` reads all three under one `Promise.all` — so that single rejection drops the whole entry and the probe would have picked a host that cannot do the job.

Not fixed here: the reason this presented as empty data rather than an error. `getUserProtocolBalances` wraps the reads in `Promise.allSettled` and never inspects the rejections, so a total failure returns `[]` — indistinguishable from "this wallet holds nothing". Tracked in Otomatorg/otomato-dapp#3046.

## Test plan
- verified on-chain that the fixture wallet `0x9ebf…99ae` still holds a real position on Mode (Ironclad `20262895`, Ionic `4`), so the data had not rotted
- ran the probe: selects `https://mainnet.mode.network`, and `getUserProtocolBalances` then returns a non-empty result, satisfying the suite's `at.least(1)` assertion
- confirmed per-RPC behaviour of the three calls the code makes:

| RPC | `balanceOf` | `decimals` | `symbol` |
|---|---|---|---|
| `mainnet.mode.network` | ok | ok | ok |
| `1rpc.io/mode` | ok | ok | ok |
| `mode.drpc.org` | ok | ok | **error** |

- `npx tsc --noEmit` clean for the changed spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7WWHa5mfSQugCeik3TVEB
