### PR TITLE
chore: sync version to 2.0.648, above npm's published 2.0.647

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otomato-sdk",
-  "version": "2.0.641",
+  "version": "2.0.648",
   "description": "An SDK for building and managing automations on Otomato",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- set `package.json` version to `2.0.648`, one above npm's published `2.0.647`

npm holds `2.0.644` … `2.0.647` (published out of band) while this repo's `package.json` sat at `2.0.641`. The bump is owned by the BMT workflow, which computes the next version from `package.json` alone and never consults the registry:

```bash
# block-management-tool/.github/workflows/prod.yml
CURRENT=$(jq -r '.version' package.json | sed 's/-beta.*//')
PATCH=$(echo $CURRENT | awk -F. '{print $3 + 1}')
```

So every release produced a version *below* npm's latest and publish refused it:

```
npm error Cannot implicitly apply the "latest" tag because previously published
version 2.0.647 is higher than the new version 2.0.641.
```

Re-basing on what npm actually has clears it in one step. The alternative was six more BMT merges climbing 642 → 647, each one a failed release.

This is a one-time correction to a drifted base, not routine hand-bumping — CI keeps ownership of the bump from here.

## Test plan
- `npm view otomato-sdk versions` → last published are `2.0.644, 2.0.645, 2.0.646, 2.0.647`; `2.0.648` is the next free version
- the preceding release (run 33831421861) already passed **203 tests** and **Build SDK**; `Publish to npm` was the only failing step, on this version comparison alone
- diff is the single `version` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7WWHa5mfSQugCeik3TVEB
