### PR TITLE
#3046 throw instead of returning [] when every balance read fails

### DIFF
--- a/src/utils/addressBalance.ts
+++ b/src/utils/addressBalance.ts
@@ -256,8 +256,8 @@ export async function getUserProtocolBalances(
 
   const results: ProtocolBalanceResult[] = [];
 
-  await Promise.allSettled(addressesToCheck.map(async ({ protocol, token }) => {
-    
+  const settled = await Promise.allSettled(addressesToCheck.map(async ({ protocol, token }) => {
+
     const contract = new ethers.Contract(token, readABI, provider);
 
     const [rawBalanceBN, decimals, symbol] = await Promise.all([
@@ -310,6 +310,33 @@ export async function getUserProtocolBalances(
       underlyingBalance,               // computed by getBalanceInUnderlying
     });
   }));
+
+  // A rejected entry is discarded from `results` above — log it so a failed
+  // read is never silently indistinguishable from "this protocol has no
+  // balance". See otomato-dapp#3046.
+  settled.forEach((outcome, i) => {
+    if (outcome.status === 'rejected') {
+      const { protocol, token } = addressesToCheck[i];
+      const reason = outcome.reason instanceof Error ? outcome.reason.message : String(outcome.reason);
+      console.error(
+        `getUserProtocolBalances: balance read failed for protocol=${protocol} token=${token} chainId=${chainId}: ${reason}`
+      );
+    }
+  });
+
+  // If every read rejected, `results` is `[]` for the same reason a genuinely
+  // empty wallet would be — a caller cannot tell "no positions" from "the RPC
+  // is down" (otomato-dapp#3046). Surface it instead of returning silently.
+  const allFailed = settled.length > 0 && settled.every((s) => s.status === 'rejected');
+  if (allFailed) {
+    const firstRejected = settled.find((s): s is PromiseRejectedResult => s.status === 'rejected')!;
+    const reason = firstRejected.reason instanceof Error ? firstRejected.reason.message : String(firstRejected.reason);
+    throw new Error(
+      `getUserProtocolBalances: all ${settled.length} balance read(s) failed for chainId=${chainId} ` +
+      `address=${address} contractAddress=${contractAddress} — likely an RPC failure, not an empty portfolio. ` +
+      `First error: ${reason}`
+    );
+  }
 
   return results;
 }

--- a/test/addressBalance.spec.ts
+++ b/test/addressBalance.spec.ts
@@ -151,4 +151,32 @@ describe('getUserProtocolBalances', function() {
       expect(err.message).to.include('No token map for chainId=99999');
     }
   });
+
+  // Regression test for otomato-dapp#3046: an all-failed read must be a
+  // visible error, never a silent [] indistinguishable from "no positions".
+  it('should throw a descriptive error when every protocol balance read fails (RPC down)', async () => {
+    const chainId = 8453;
+    const address = '0x757A004bE766f745fd4CD75966CF6C8Bb84FD7c1';
+    const baseUSDC = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+
+    // Point Base at an unreachable host so every contract call rejects with a
+    // deterministic ECONNREFUSED — no network flakiness, no timeout wait.
+    rpcServices.setRPCs({ 8453: 'http://127.0.0.1:1' });
+
+    try {
+      await getUserProtocolBalances({ chainId, address, contractAddress: baseUSDC });
+      expect.fail('Expected getUserProtocolBalances to throw when every read fails');
+    } catch (err: any) {
+      expect(err.message).to.include('all');
+      expect(err.message).to.include('balance read(s) failed');
+      expect(err.message).to.include(`chainId=${chainId}`);
+      expect(err.message).to.not.equal('No token map for chainId=99999'); // sanity: didn't hit the wrong branch
+    } finally {
+      // Restore — this is the last test in the file, but keep the suite
+      // order-independent for anything added after it later.
+      rpcServices.setRPCs({
+        8453: process.env.BASE_HTTPS_PROVIDER || 'https://base.llamarpc.com',
+      });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- `getUserProtocolBalances` returns `[]` when every RPC call fails — `Promise.allSettled` discards rejections and nothing inspects the settled array, so an RPC outage is indistinguishable from a wallet holding no positions
- now throws a descriptive error (chain, wallet, token, first real RPC error) when 100% of reads fail, and logs every individual rejection unconditionally so a partial failure is visible too
- the success path (some or all reads resolve) is unchanged
## Test plan

- `test/addressBalance.spec.ts` — new regression test `should throw a descriptive error when every protocol balance read fails (RPC down)`: points `rpcServices` at an unreachable host (`http://127.0.0.1:1`) so all 18 protocol reads for USDC-on-Base reject deterministically, asserts the function throws (not `[]`).
- Full spec run against a live, healthy Base RPC (`BASE_HTTPS_PROVIDER=https://base.publicnode.com`): 4/4 PASS, including the real 18-entry success path and the WALLET-fallback path, unchanged.
- Full suite (`npm test`) run against default config: 197 passing / 1 pending / 3 failing — the 3 failures are pre-existing and unrelated: 2 come from `base.llamarpc.com` (the suite's default RPC) genuinely returning HTTP 521 at run time (would fail identically on unmodified code — `Promise.allSettled` already discarded all-rejected before this diff), 1 from a missing `API_KEY` env var in an unrelated spec (`test/apiKey.spec.ts`).
- Live before/after repro (`/tmp/repro-3046.mjs`): same params, same broken RPC — before returns `[]` silently, after throws `getUserProtocolBalances: all N balance read(s) failed... likely an RPC failure, not an empty portfolio. First error: ...`. See QA report for full output + screenshots.
- Blast radius: grepped for `getUserProtocolBalances` callers across every local clone. One found — `custom-handler/src/agents/agent-aggre/handler.js:736` — already wraps the call in try/catch and logs `error.message`; verified by reading, no code change needed there, no test run needed (repo unchanged).

Full QA report (repro, root cause, code walkthrough, robustness matrix): https://html.otomato.xyz/reports/3046-sdk-getuserprotocolbalances-rpc-swallow-2026-09-04.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)
