### PR TITLE
force mocha to exit after the run completes

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -4,5 +4,6 @@
   "node-option": [
     "experimental-specifier-resolution=node",
     "loader=ts-node/esm"
-  ]
+  ],
+  "exit": true
 }


### PR DESCRIPTION
## Summary
- CI's "SDK Release" job hung indefinitely on "Run tests" twice in a row while merging otomato-sdk#152 — a flaky/unreachable public RPC in a live-network test leaves ethers `JsonRpcProvider` retry loops open, and without `--exit` the mocha process never terminates once the report is printed, running until GitHub's 6h default job timeout
- add `"exit": true` to `.mocharc.json` so the process always terminates once the test run completes, regardless of lingering handles

## Test plan
- Confirmed locally: the same command run WITHOUT `--exit` left the process alive (had to be killed) after already printing its full pass/fail summary; the same command WITH `--exit` (used as this ticket's own evidence-gathering run) completed and returned exit code 0 promptly