### PR TITLE
chore: bump version to 2.0.649

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otomato-sdk",
-  "version": "2.0.648",
+  "version": "2.0.649",
   "description": "An SDK for building and managing automations on Otomato",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- npm already holds 2.0.648 (published earlier today) but package.json wasn't bumped when #3046's fix (otomato-sdk#152) or the mocharc --exit fix merged, so "Publish to npm" failed on both merges with "cannot publish over the previously published versions: 2.0.648"
- one-time re-sync, same pattern as b76fcff