### PR TITLE
#3032 map Robinhood Chain (4663) to the DeFi Llama slug

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -214,6 +214,11 @@ export const CHAIN_ID_TO_LLAMA_SLUG: Record<number, string> = {
   [CHAINS.AVALANCHE]: 'avax',
   [CHAINS.INK]: 'ink',
   [CHAINS.SCROLL]: 'scroll',
+  // #3038 added Robinhood Chain to CHAINS after #3032 was written. Slug probed 2026-09-08:
+  // 'robinhood' prices GOOGL 0x2e0847E8... AND USDG 0x5fc5360D...; 'robinhoodchain' is a
+  // partial alias returning USDG only. Native 0x0 resolves to ETH on BOTH, so the native
+  // sentinel alone does not disambiguate them - always probe a real ERC20.
+  [CHAINS.ROBINHOOD]: 'robinhood',
 };
 
 const LLAMA_PRICES_URL = 'https://coins.llama.fi/prices/current/';


### PR DESCRIPTION
## Summary
- `#3038` added `CHAINS.ROBINHOOD` after `#3032` was written; once BMT regenerated `Blocks.ts`, the #3032 chain-coverage test failed and **SDK master could no longer publish** (run 34190815950).
- Adds `[CHAINS.ROBINHOOD]: 'robinhood'`.

Slug probed against real chain-4663 tokens, not read from docs: `robinhood` prices GOOGL `0x2e0847E8…` ($337.94) **and** USDG `0x5fc5360D…`; the `robinhoodchain` alias returns USDG only. The native `0x0` sentinel resolves to ETH on both, so it does not disambiguate them.

## Test plan
- `npm test` — `#3032 chain coverage` passes (was the sole failure on master).
- Remaining local failures are environmental only (base.llamarpc.com 525, missing `API_KEY`); CI has the secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQPS29wxkBMshoEoeNjSAz